### PR TITLE
Don't make `build` and alias for `bdist_wheel`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,8 +95,7 @@ filterwarnings =
     ignore:::statsmodels.base.wrapper:100
 
 [aliases]
-build = bdist_wheel
-release = build upload
+release = bdist_wheel upload
 
 [bdist_wheel]
 # Use this option if your package is pure-python


### PR DESCRIPTION
Lots of downstream packagers use `setup.py build` to build the package before installing it with `setup.py install`.  Making `setup.py build` run `setup.py bdist_wheel` breaks this workflow.